### PR TITLE
追加したメニューアイテム用のコンポーネントを作成した

### DIFF
--- a/components/MenuItem.tsx
+++ b/components/MenuItem.tsx
@@ -1,0 +1,110 @@
+import styled from "@emotion/styled";
+import { Card, CardActions, IconButton } from "@mui/material";
+import NoPhotographyOutlinedIcon from "@mui/icons-material/NoPhotographyOutlined";
+import FavoriteBorderOutlinedIcon from "@mui/icons-material/FavoriteBorderOutlined";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { theme } from "styles/theme";
+
+type ComponentProps = {
+  imageUrl?: string;
+  name: string;
+  price: number;
+  onClickDelete: () => void;
+  onClickFavorite: () => void;
+};
+
+const Component: FCX<ComponentProps> = ({
+  className,
+  imageUrl,
+  name,
+  price,
+  onClickDelete,
+  onClickFavorite,
+}) => (
+  <Card className={className}>
+    <div className="image-container">
+      {imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img className="image" src={imageUrl} alt={name} />
+      ) : (
+        <div className="no-image">
+          <NoPhotographyOutlinedIcon className="icon" />
+        </div>
+      )}
+    </div>
+
+    <div className="description">
+      <div className="name">{name}</div>
+      <div className="price">{price.toLocaleString()}円</div>
+    </div>
+
+    <CardActions className="buttons">
+      <IconButton onClick={onClickDelete}>
+        <DeleteOutlineIcon />
+      </IconButton>
+      <IconButton onClick={onClickFavorite}>
+        <FavoriteBorderOutlinedIcon />
+      </IconButton>
+    </CardActions>
+  </Card>
+);
+
+const StyledComponent = styled(Component)`
+  display: flex;
+  height: 56px;
+
+  > .image-container {
+    flex-shrink: 0;
+    width: 56px;
+    height: 56px;
+    > .image {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    > .no-image {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background: ${theme.palette.grey[300]};
+      > .icon {
+        fill: ${theme.palette.common.white};
+      }
+    }
+  }
+
+  > .description {
+    flex-grow: 1;
+    overflow: hidden;
+    padding: ${theme.spacing(1, 0, 1, 1)};
+    > .name {
+      font-size: 14px;
+      font-weight: bold;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: ${theme.spacing(0.5)};
+    }
+    > .price {
+      font-size: 10px;
+    }
+  }
+
+  > .buttons {
+    flex-shrink: 0;
+  }
+`;
+
+export const MenuItem = () => {
+  const componentProps: ComponentProps = {
+    name: "小エビのサラダ",
+    price: 350,
+    onClickDelete: () => {}, // 後で設定する
+    onClickFavorite: () => {}, // 後で設定する
+  };
+
+  return <StyledComponent {...componentProps} />;
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,11 @@
 import Head from "next/head";
 import styled from "@emotion/styled";
-import { Container } from "@mui/material";
+import { Container, Stack } from "@mui/material";
 import { Header } from "components/Header";
 import { TotalPrice } from "components/TotalPrice";
 import { TweetButton } from "components/TweetButton";
 import { OrderButton } from "components/OrderButton";
+import { MenuItem } from "components/MenuItem";
 import { theme } from "styles/theme";
 
 const Component: FCX = ({ className }) => (
@@ -29,6 +30,12 @@ const Component: FCX = ({ className }) => (
             <OrderButton />
           </div>
         </div>
+
+        <Stack spacing={2}>
+          {[1, 2, 3].map((n) => (
+            <MenuItem key={n} />
+          ))}
+        </Stack>
       </Container>
     </div>
   </>
@@ -45,6 +52,7 @@ const StyledComponent = styled(Component)`
 
     > .top {
       display: flex;
+      margin-bottom: ${theme.spacing(2)};
       > .buttons {
         flex: 1;
         display: flex;


### PR DESCRIPTION
* 追加したメニューアイテム用のコンポーネントを作成した
  * 画像がない場合はno-imageぽい画像を表示
  * 横幅足らず商品名が表示できないときは...で切る

| before | after(imageあり&商品名長め) | after(no-image) |
| :---: | :---: | :---: |
| <img width="279" alt="スクリーンショット 2023-01-09 18 56 07" src="https://user-images.githubusercontent.com/13055960/211281908-cb345ea0-5c86-4f5f-b41d-f79bbc255e62.png"> | <img width="279" alt="スクリーンショット 2023-01-09 20 52 29" src="https://user-images.githubusercontent.com/13055960/211302212-48d1dc87-ce7d-4bef-9a43-27e6ee40bd51.png"> |<img width="279" alt="スクリーンショット 2023-01-09 20 50 17" src="https://user-images.githubusercontent.com/13055960/211301824-9e57f347-475c-4065-afc5-66a4c12335bd.png"> |